### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+---
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Release
+        id: setup_release
+        uses: LizardByte/setup-release-action@v2023.10.22-858d72b
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create/Update GitHub Release
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/master') &&
+          steps.setup_release.outputs.publish_release == 'true'
+        uses: LizardByte/create-release-action@v2023.10.22-57d76be
+        with:
+          allowUpdates: true
+          artifacts: ""
+          body: ${{ steps.setup_release.outputs.release_body }}
+          discussionCategory: announcements
+          generateReleaseNotes: ${{ steps.setup_release.outputs.release_generate_release_notes }}
+          name: ${{ steps.setup_release.outputs.release_tag }}
+          prerelease: ${{ steps.setup_release.outputs.publish_pre_release }}
+          tag: ${{ steps.setup_release.outputs.release_tag }}
+          token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds a release workflow and prepares for the new org release methodology.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
